### PR TITLE
Fix default option name  `textDomain` >`textdomain

### DIFF
--- a/lib/addtextdomain.js
+++ b/lib/addtextdomain.js
@@ -29,7 +29,7 @@ module.exports = function(files, options) {
   options = _.merge({
     cwd: process.cwd(),
     dryRun: false,
-    textDomain: '',
+    textdomain: '',
     updateDomains: []
   }, options);
 


### PR DESCRIPTION
...because everywhere else it is all lowercase