### PR TITLE
Exclude the Composer vendor directory by default

### DIFF
--- a/lib/makepot.js
+++ b/lib/makepot.js
@@ -57,8 +57,9 @@ module.exports = function(options) {
   // Create the domain path directory if it doesn't exist.
   mkdirp.sync(wpPackage.getPath(wpPackage.getDomainPath()));
 
-  // Exclude the node_modules directory by default.
+  // Exclude the node_modules and vendor directories by default.
   options.exclude.push('node_modules/.*');
+  options.exclude.push('vendor/.*');
 
   var originalPot = wpPackage.getPot();
 


### PR DESCRIPTION
Plugins are likely to have this directory full of Composer dependencies that should be excluded.