### PR TITLE
Fixed issues when plugin file was guessed by slug.

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -57,7 +57,7 @@ function findMainFile(wpPackage) {
 
   // Check if the main file exists.
   if (util.fileExists(filename) && wpPackage.getHeader('Plugin Name', filename)) {
-    return pluginFile;
+    return filename;
   }
 
   // Search for plugin headers in php files in the main directory.


### PR DESCRIPTION
If the plugin file was guessed by slug the `findMainFile` would return only the (relative) plugin filename, if it was found by globbing the PHP files in the main directory it returns a full absolute path to the main plugin file. This resulted in a bugs when the main plugin file was guessed by slug.