### PR TITLE
Add exclude option to `makepot` cli command

### DIFF
--- a/bin/wpi18n
+++ b/bin/wpi18n
@@ -11,6 +11,7 @@ var WPPackage = require('../lib/package');
 var argv = require('minimist')(process.argv.slice(2), {
   string: [
     'domain-path',
+		'exclude',
     'main-file',
     'pot-file',
     'textdomain',
@@ -78,6 +79,7 @@ if (-1 !== argv._.indexOf('makepot')) {
 
   wpi18n.makepot({
     domainPath: argv['domain-path'] ? argv['domain-path'] : '',
+		exclude: argv['exclude'] ? argv['exclude'].split(',') : '',
     mainFile: argv['main-file'] ? argv['main-file'] : '',
     potHeaders: headers,
     potFile: argv['pot-file'] ? argv['pot-file'] : '',

--- a/bin/wpi18n
+++ b/bin/wpi18n
@@ -11,7 +11,7 @@ var WPPackage = require('../lib/package');
 var argv = require('minimist')(process.argv.slice(2), {
   string: [
     'domain-path',
-		'exclude',
+    'exclude',
     'main-file',
     'pot-file',
     'textdomain',
@@ -79,7 +79,7 @@ if (-1 !== argv._.indexOf('makepot')) {
 
   wpi18n.makepot({
     domainPath: argv['domain-path'] ? argv['domain-path'] : '',
-		exclude: argv['exclude'] ? argv['exclude'].split(',') : '',
+    exclude: argv['exclude'] ? argv['exclude'].split(',') : '',
     mainFile: argv['main-file'] ? argv['main-file'] : '',
     potHeaders: headers,
     potFile: argv['pot-file'] ? argv['pot-file'] : '',

--- a/docs/cli.txt
+++ b/docs/cli.txt
@@ -11,6 +11,7 @@ Options:
   -v, --version           Display the current version.
   -h, --help              Display help and usage details.
   --domain-path           Relative path to the POT file directory.
-  --main-file             Name of the main package file.
+  --exclude               Exclude directories. Separate multiple directories by comma (`,`)
+  --main-file             Name of the main package file.
   --pot-file              Name of the POT file.
   --type                  Type of package (plugin or theme).

--- a/docs/cli.txt
+++ b/docs/cli.txt
@@ -11,7 +11,7 @@ Options:
   -v, --version           Display the current version.
   -h, --help              Display help and usage details.
   --domain-path           Relative path to the POT file directory.
-  --exclude               Exclude directories. Separate multiple directories by comma (`,`)
+  --exclude               Exclude directories. Separate multiple directories by comma.
   --main-file             Name of the main package file.
   --pot-file              Name of the POT file.
   --type                  Type of package (plugin or theme).


### PR DESCRIPTION
Allows running e.g.:

```bash
wpi18n makepot \
    --domain-path=/languages \
    --main-file=jetpack.php \
    --pot-file=jetpack.pot \
    --exclude=docker,node_modules,tests,tools,vendor
```