### PR TITLE
Support passing custom glob-pattern for addtextdomain cli

### DIFF
--- a/bin/wpi18n
+++ b/bin/wpi18n
@@ -11,6 +11,7 @@ var WPPackage = require('../lib/package');
 var argv = require('minimist')(process.argv.slice(2), {
   string: [
     'domain-path',
+    'glob-pattern',
     'main-file',
     'pot-file',
     'textdomain',
@@ -41,7 +42,8 @@ if (argv.version) {
 }
 
 if (-1 !== argv._.indexOf('addtextdomain')) {
-  var files = glob.sync('**/*.php');
+  var pattern = argv['glob-pattern'] ? argv['glob-pattern'] : '**/*.php';
+  var files = glob.sync(pattern);
 
   wpi18n.addtextdomain(files, {
     dryRun: argv['dry-run'],


### PR DESCRIPTION
This would allow doing this:

```
wpi18n addtextdomain \
    --textdomain=jetpack \
    --glob-pattern='!(docker|node_modules|tests|tools|vendor){*.php,**/*.php}'
```

or:
```
wpi18n addtextdomain \
    --textdomain=jetpack \
    --glob-pattern=*.php
```