### PR TITLE
Fix `exclude` variable default in bin script.

### DIFF
--- a/bin/wpi18n
+++ b/bin/wpi18n
@@ -81,7 +81,7 @@ if (-1 !== argv._.indexOf('makepot')) {
 
   wpi18n.makepot({
     domainPath: argv['domain-path'] ? argv['domain-path'] : '',
-    exclude: argv['exclude'] ? argv['exclude'].split(',') : '',
+    exclude: argv['exclude'] ? argv['exclude'].split(',') : [],
     mainFile: argv['main-file'] ? argv['main-file'] : '',
     potHeaders: headers,
     potFile: argv['pot-file'] ? argv['pot-file'] : '',


### PR DESCRIPTION
Prior to this change, calling `wi18n makepot` in a terminal would produce an error: "options.exclude.push is not a function".

The default value was being passed as an empty string, instead of an empty array.