### PR TITLE
Replace continue statement inside a switch

### DIFF
--- a/bin/php/pomo/plural-forms.php
+++ b/bin/php/pomo/plural-forms.php
@@ -207,7 +207,7 @@ class Plural_Forms {
 						$span     = strspn( $str, self::NUM_CHARS, $pos );
 						$output[] = array( 'value', intval( substr( $str, $pos, $span ) ) );
 						$pos     += $span;
-						continue;
+						break;
 					}
 
 					throw new Exception( sprintf( 'Unknown symbol "%s"', $next ) );


### PR DESCRIPTION
As in the upstream pomo, this `continue` is meant to be a `break`

Source update in https://github.com/LeoColomb/pomo/blob/master/src/Parser/PluralForms.php

Not sure how this dependency is managed. if its imported other than manually, please ignore this PR and pull from origin.