### PR TITLE
Fixes PHP8 warning while generating POT files

### DIFF
--- a/bin/php/pomo/po.php
+++ b/bin/php/pomo/po.php
@@ -212,11 +212,11 @@ class PO extends Gettext_Translations {
 	 * Builds a string from the entry for inclusion in PO file
 	 *
 	 * @static
-	 * @param Translation_Entry $entry the entry to convert to po string (passed by reference).
+	 * @param Translation_Entry $entry the entry to convert to po string.
 	 * @return false|string PO-style formatted string for the entry or
 	 *  false if the entry is empty
 	 */
-	public static function export_entry( &$entry ) {
+	public static function export_entry( $entry ) {
 		if ( null === $entry->singular || '' === $entry->singular ) {
 			return false;
 		}


### PR DESCRIPTION
Fixed based on https://core.trac.wordpress.org/changeset/49186