### PR TITLE
Added "update-po-files" argument

### DIFF
--- a/bin/wpi18n
+++ b/bin/wpi18n
@@ -22,7 +22,8 @@ var argv = require('minimist')(process.argv.slice(2), {
     'dry-run',
     'help',
     'poedit',
-    'version'
+    'version',
+    'update-po-files'
   ],
   alias: {
     h: 'help',
@@ -103,7 +104,8 @@ if (-1 !== argv._.indexOf('makepot')) {
     potHeaders: headers,
     potFile: argv['pot-file'] ? argv['pot-file'] : '',
     type: argv.type ? 'wp-' + argv.type.replace('wp-', '') : '',
-    updateTimestamp: false
+    updateTimestamp: false,
+    updatePoFiles: argv['update-po-files']
   }).then(function() {
 
   });


### PR DESCRIPTION
Hi there,

In some of our projects we have the need to update existing `.po` files after the `.pot` file is updated.

The functionality [is already available](https://github.com/cedaro/node-wp-i18n/blob/develop/lib/makepot.js#L103). However it seems the option is never parsed from command line? [Here](https://github.com/cedaro/node-wp-i18n/blob/develop/bin/wpi18n#L12) and [here](https://github.com/cedaro/node-wp-i18n/blob/develop/bin/wpi18n#L106).

This pull request adds a `update-po-files` argument so that the `updatePoFiles` option is properly sent through the `makepot` function.

You can update existing `.po` files by running this command:

```
wpi18n makepot --update-po-files
```