### PR TITLE
#fix php notice

### DIFF
--- a/bin/php/makepot.php
+++ b/bin/php/makepot.php
@@ -8,6 +8,15 @@ if ( ! defined( 'STDERR' ) ) {
 }
 
 class MakePOT {
+
+	/**
+	 * Supported from PHP 7.4
+	 * @var StringExtractor
+	 */
+	//private StringExtractor $extractor;
+
+	private $extractor;
+
 	public $max_header_lines = 30;
 
 	public $projects = array(


### PR DESCRIPTION
- fixing php deprecation notice when running grunt addtextdomain tasks.

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7007821/218736288-919c608a-a656-4df9-b9a9-85523a5f6fab.png">
